### PR TITLE
add nw-tourism 2 changes

### DIFF
--- a/[Shared] Pools and Definitions/README.md
+++ b/[Shared] Pools and Definitions/README.md
@@ -60,6 +60,7 @@ Fast approach:
 
 ## Changes
 
+- 8: Replace NW tourist need of fur coats with ponchos
 - 7: Added pools for motor assembly plant and subway station
 - 7: Renamed most pool names from plural / 'all' to singular
 - 6: Added pools for oil power plants, and various other productions

--- a/[Shared] Pools and Definitions/data/config/export/main/asset/assets-hotel-needs.include.xml
+++ b/[Shared] Pools and Definitions/data/config/export/main/asset/assets-hotel-needs.include.xml
@@ -42,7 +42,7 @@
       <NoWeightPopulationCount>49</NoWeightPopulationCount>
       <RequiredBuildings>
         <Item>
-          <RequiredBuilding>0</RequiredBuilding>
+          <RequiredBuilding>1440134300</RequiredBuilding>
           <Region>Colony01</Region>
         </Item>
       </RequiredBuildings>
@@ -59,7 +59,7 @@
       <NoWeightPopulationCount>2499</NoWeightPopulationCount>
       <RequiredBuildings>
         <Item>
-          <RequiredBuilding>0</RequiredBuilding>
+          <RequiredBuilding>1440134300</RequiredBuilding>
           <Region>Colony01</Region>
         </Item>
       </RequiredBuildings>
@@ -75,16 +75,35 @@
       <MoneyValue>75</MoneyValue>
       <RequiredBuildings>
         <Item>
-          <RequiredBuilding>0</RequiredBuilding>
+          <RequiredBuilding>1440134300</RequiredBuilding>
           <Region>Colony01</Region>
         </Item>
       </RequiredBuildings>
     </Item>
   </ModOp>
+  <ModOp Type="addNextSibling" GUID="601379"
+    Condition="!~/Values/PopulationLevel7/PopulationInputs/Item[Product='120043']"
+    Path="/Values/PopulationLevel7/PopulationInputs/Item[Product='1010247']">
+    <Item>
+      <Product>120043</Product>
+      <Amount>0.01666667</Amount>
+      <HappinessValue>3</HappinessValue>
+      <MoneyValue>40</MoneyValue>
+      <FullWeightPopulationCount>75</FullWeightPopulationCount>
+      <NoWeightPopulationCount>49</NoWeightPopulationCount>
+      <RequiredBuildings>
+        <Item>
+          <RequiredBuilding>1440134300</RequiredBuilding>
+          <Region>Colony01</Region>
+        </Item>
+      </RequiredBuildings>
+    </Item>
+  </ModOp>
+
   <!-- copy needs from vanilla hotel -->
   <ModOp Type="add" GUID="601379"
     AllowNoMatch="1"
-    Path="/Values/PopulationLevel7/PopulationInputs/Item[not(RequiredBuildings/Item/RequiredBuilding='1440134300') and (Product&lt;1010500) and not(Product='133573') and not(Product='132761') and not(Product='133536') and not(Product='137757')]/RequiredBuildings">
+    Path="/Values/PopulationLevel7/PopulationInputs/Item[not(RequiredBuildings/Item/RequiredBuilding='1440134300') and (Product&lt;1010500) and not(Product='133573') and not(Product='132761') and not(Product='133536') and not(Product='137757') and not(Product='1010247') and not(Product='134257')]/RequiredBuildings">
     <Item>
       <RequiredBuilding>1440134300</RequiredBuilding>
       <Region>Colony01</Region>

--- a/[Shared] Pools and Definitions/modinfo.json
+++ b/[Shared] Pools and Definitions/modinfo.json
@@ -1,5 +1,5 @@
 {
-  "Version": "7.1",
+  "Version": "8.0",
   "ModID": "shared-pools-and-definitions",
   "DepecrateIds": [ "jakob_shared_base" ],
   "Category": {


### PR DESCRIPTION
NW Tourism 1.2 doesn't use this shared mod yet but will in 2.0.
Thus the changes are not effective yet and can safely be merged.