### PR TITLE
10.5.1

### DIFF
--- a/[Shared] Pools and Definitions/data/config/export/main/asset/assets-pools.include.xml
+++ b/[Shared] Pools and Definitions/data/config/export/main/asset/assets-pools.include.xml
@@ -1224,15 +1224,6 @@
               <Item>
                 <GUID>1500301920</GUID>
               </Item>
-              <Item>
-                <GUID>112667</GUID>
-              </Item>
-              <Item>
-                <GUID>112673</GUID>
-              </Item>
-              <Item>
-                <GUID>116034</GUID>
-              </Item>
             </EffectTargetGUIDs>
           </ItemEffectTargetPool>
         </Values>

--- a/[Shared] Pools and Definitions/modinfo.json
+++ b/[Shared] Pools and Definitions/modinfo.json
@@ -1,5 +1,5 @@
 {
-  "Version": "10.5",
+  "Version": "10.5.1",
   "ModID": "shared-pools-and-definitions",
   "DepecrateIds": [ "jakob_shared_base" ],
   "Category": {


### PR DESCRIPTION
Remove arctic hunting cabins from "All Hunting Cabins" to keep the same vanilla structure as the pools for lumberjacks and charcoal kilns.